### PR TITLE
feat/ login page bootstraped

### DIFF
--- a/user_area/user_login.php
+++ b/user_area/user_login.php
@@ -15,8 +15,8 @@ include('../functions/common_funk.php');
       crossorigin="anonymous">
 </head>
 <body>
-    <div class="container-fluid">
-        <h1 class="text-center">User Login </h1>
+    <div class="card bg-dark text-white py-5 container-fluid">
+        <h1 class="text-center py-5 h-100">User Login </h1>
         <div class="row align-items-center justify-content-center">
             <div class="col-lg-12 col-xl-6">
                     <form action="" method="post" >
@@ -33,8 +33,8 @@ include('../functions/common_funk.php');
                         autocomplete="off" required="required" name="user_password">
                     </div>
                     <div >
-                        <input type="submit" value="Log in" class="bg-info py-2 px-3 border-0" name="user_login">
-                        <p class="small fw-bold mt-2 pt-2 mb-5">Don't have an account ? <a href="user_register.php" class="text-danger">Register</a></p>
+                        <input type="submit" value="Log in" class="btn btn-primary btn-block mb-4" name="user_login">
+                        <p class="small fw-bold mt-2 pt-2 mb-5 text-center">Don't have an account ? <a href="user_register.php" class="text-danger">Register</a></p>
                     </div>
                     </form>
             </div>


### PR DESCRIPTION
fixes #9 

current page contains minor margin and padding calculation mistakes due to which page is floating over top. Which somehow reduces the user experience.

![image](https://github.com/FashionFinds/FashionFinds-Web/assets/121279876/d4daffa2-3a9f-4063-be56-687a64171242)

Proposed Solution:

Contains the bootstrapping of the elements and added an background-color which focuses on the subject content.

![image](https://github.com/FashionFinds/FashionFinds-Web/assets/121279876/d66ce83d-1dda-45c3-a1e3-f2bced0fd8e2)
